### PR TITLE
B2B-1719: Android - Link fails on transfer bc of missing `fromAddress` field

### DIFF
--- a/link/src/main/java/com/meshconnect/link/converter/TransferFinishedPayloadDeserializer.kt
+++ b/link/src/main/java/com/meshconnect/link/converter/TransferFinishedPayloadDeserializer.kt
@@ -15,7 +15,10 @@ internal class TransferFinishedPayloadDeserializer : JsonDeserializer<TransferFi
         typeOfT: Type,
         context: JsonDeserializationContext
     ): TransferFinishedPayload {
-        val obj = json.asJsonObject
+        val obj = json.asJsonObject.apply {
+            if (!has("fromAddress")) addProperty("fromAddress", "")
+            if (!has("toAddress")) addProperty("toAddress", "")
+        }
         return when (val status = obj.get("status").asString) {
             "success" -> context.deserialize<TransferFinishedSuccessPayload>(obj)
             "error" -> context.deserialize<TransferFinishedErrorPayload>(obj)

--- a/link/src/test/kotlin/com/meshconnect/link/converter/TransferFinishedPayloadDeserializerTest.kt
+++ b/link/src/test/kotlin/com/meshconnect/link/converter/TransferFinishedPayloadDeserializerTest.kt
@@ -13,7 +13,7 @@ class TransferFinishedPayloadDeserializerTest {
     private val gson = JsonConverter.get()
 
     @Test
-    fun testSuccess() {
+    fun `test success payload`() {
         val json = readFile("transfer-success.json")
         val actual = gson.fromJson<TransferFinishedPayload>(json)
         val expected = TransferFinishedSuccessPayload(
@@ -28,7 +28,22 @@ class TransferFinishedPayloadDeserializerTest {
     }
 
     @Test
-    fun testError() {
+    fun `test success payload with empty address`() {
+        val json = readFile("transfer-success-empty-address.json")
+        val actual = gson.fromJson<TransferFinishedPayload>(json)
+        val expected = TransferFinishedSuccessPayload(
+            txId = "234sdf-xxx3902",
+            fromAddress = "",
+            toAddress = "",
+            symbol = "UST",
+            amount = 1.0024,
+            networkId = "79823981e"
+        )
+        assert(actual == expected)
+    }
+
+    @Test
+    fun `test error payload`() {
         val json = readFile("transfer-error.json")
         val actual = gson.fromJson<TransferFinishedPayload>(json)
         val expected = TransferFinishedErrorPayload(
@@ -38,7 +53,7 @@ class TransferFinishedPayloadDeserializerTest {
     }
 
     @Test
-    fun testNull() {
+    fun `test invalid status`() {
         val json = "{status:'lorem'}"
         val ex = assertThrows(JsonSyntaxException::class.java) {
             gson.fromJson<TransferFinishedPayload>(json)

--- a/link/src/test/kotlin/com/meshconnect/link/ui/LinkViewModelTest.kt
+++ b/link/src/test/kotlin/com/meshconnect/link/ui/LinkViewModelTest.kt
@@ -32,7 +32,7 @@ class LinkViewModelTest : ViewModelTest() {
     fun `verify viewModel emits error`() = runTest {
         val th = mockk<Throwable>()
         val errorObserver = viewModel.throwable.testObserver()
-        coEvery { getLinkEventUseCase.launch("") } returns Result.failure(th)
+        coEvery { getLinkEventUseCase.launch(any()) } returns Result.failure(th)
         coEvery { broadcastLinkMessageUseCase.launch(any()) } returns Result.success(Unit)
         viewModel.onJsonReceived("")
 
@@ -46,7 +46,7 @@ class LinkViewModelTest : ViewModelTest() {
             every { payload } returns mockk()
         }
         val eventObserver = viewModel.linkEvent.testObserver()
-        coEvery { getLinkEventUseCase.launch("") } returns Result.success(payload)
+        coEvery { getLinkEventUseCase.launch(any()) } returns Result.success(payload)
         coEvery { payloadReceiver.emit(payload.payload) } just Runs
         coEvery { broadcastLinkMessageUseCase.launch(any()) } returns Result.success(Unit)
         viewModel.onJsonReceived("")
@@ -60,7 +60,7 @@ class LinkViewModelTest : ViewModelTest() {
     fun `verify viewModel emits 'done' event`() {
         val event = LinkEvent.Done
         val eventObserver = viewModel.linkEvent.testObserver()
-        coEvery { getLinkEventUseCase.launch("") } returns Result.success(event)
+        coEvery { getLinkEventUseCase.launch(any()) } returns Result.success(event)
         coEvery { broadcastLinkMessageUseCase.launch(any()) } returns Result.success(Unit)
         viewModel.onJsonReceived("")
 

--- a/link/src/test/resources/transfer-success-empty-address.json
+++ b/link/src/test/resources/transfer-success-empty-address.json
@@ -1,0 +1,7 @@
+{
+    "status": "success",
+    "txId": "234sdf-xxx3902",
+    "symbol": "UST",
+    "amount": 1.0024,
+    "networkId": "79823981e"
+}


### PR DESCRIPTION
Being decided to have default empty string values to don't break the backward compatibility.