### PR TITLE
Fix R8 -flattenpackagehierarchy leaking into consumer apps

### DIFF
--- a/link/build.gradle
+++ b/link/build.gradle
@@ -22,7 +22,7 @@ android {
         minSdk 24
         targetSdk 36
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
-        consumerProguardFiles 'proguard-rules.pro'
+        consumerProguardFiles 'consumer-rules.pro'
         versionCode 1
     }
     buildTypes {

--- a/link/consumer-rules.pro
+++ b/link/consumer-rules.pro
@@ -1,0 +1,32 @@
+# Consumer ProGuard/R8 rules.
+#
+# These rules are bundled into the published AAR (via `consumerProguardFiles`)
+# and merged into the CONSUMING app's R8 configuration. Keep this file limited to
+# rules that protect the Mesh SDK's public API and runtime reflection.
+#
+# IMPORTANT: never add global directives here (e.g. -flattenpackagehierarchy,
+# -repackageclasses, -overloadaggressively, optimization flags). They apply to the
+# ENTIRE consuming app and will rename/repackage the consumer's own classes. The
+# SDK's own build-time obfuscation belongs in proguard-rules.pro, not here.
+
+# Retain annotations (e.g. Gson @SerializedName) and inner classes on kept SDK
+# types so runtime (de)serialization of entities keeps working in the consumer app.
+-keepattributes *Annotation*, InnerClasses
+
+# Mesh SDK public API surface.
+-keep class com.meshconnect.link.entity.** { *; }
+-keep class com.meshconnect.link.ui.LaunchLink { *; }
+-keep class com.meshconnect.link.ui.LinkExit { *; }
+-keep class com.meshconnect.link.ui.LinkResult { *; }
+-keep class com.meshconnect.link.ui.LinkSuccess { *; }
+-keep class com.meshconnect.link.LinkEventsKt { *; }
+-keep class com.meshconnect.link.LinkPayloadsKt { *; }
+
+#--------- Begin: proguard configuration for Gson ------------
+# The SDK uses Gson at runtime to (de)serialize entities in the consumer process.
+# https://github.com/google/gson/blob/master/examples/android-proguard-example/proguard.cfg
+-keep public class * implements java.lang.reflect.Type
+# Retain generic signatures of TypeToken and its subclasses with R8 version 3.0 and higher.
+-keep,allowobfuscation,allowshrinking class com.google.gson.reflect.TypeToken
+-keep,allowobfuscation,allowshrinking class * extends com.google.gson.reflect.TypeToken
+#--------- End: proguard configuration for Gson ------------

--- a/link/proguard-rules.pro
+++ b/link/proguard-rules.pro
@@ -19,6 +19,12 @@
 
 # ProGuard/R8 obfuscation option that moves all obfuscated classes into a single flat package
 # (or a specified package), collapsing the original package structure.
+#
+# This is a GLOBAL R8 directive: it repackages every renamed package in the current
+# R8 run into com.meshconnect.link. It is safe ONLY for the SDK's own release build
+# (this file). It MUST NOT live in consumer-rules.pro / consumerProguardFiles — there
+# the R8 scope is the whole consuming app, so it would repackage the consumer's own
+# classes under com.meshconnect.link and corrupt their logs/stack traces.
 -flattenpackagehierarchy com.meshconnect.link
 
 # If you keep the line number information, uncomment this to


### PR DESCRIPTION
## Overview

A partner reported that the Mesh Android SDK's R8 rules were renaming **their own** app classes into the `com.meshconnect.link` package, making their logs and stack traces unreadable.

**Root cause:** `link/build.gradle` declared `consumerProguardFiles 'proguard-rules.pro'`, and that file contains the global directive `-flattenpackagehierarchy com.meshconnect.link`. Consumer ProGuard files are baked into the published AAR and merged into every consuming app's R8 run. The argument to `-flattenpackagehierarchy` is the *repackage destination*, not a filter — so during a consumer build (where R8's scope is the entire app) it moved **all** of the consumer's obfuscated classes under `com.meshconnect.link`. That is exactly the reported symptom.

The (previously empty, unreferenced) `consumer-rules.pro` is now the consumer file and contains only what consumers legitimately need.

## Changes

- **`link/consumer-rules.pro`** — populated with only the public-API `-keep` rules, Gson runtime rules, and `-keepattributes *Annotation*,InnerClasses`. No global directives.
- **`link/build.gradle`** — `consumerProguardFiles 'proguard-rules.pro'` → `'consumer-rules.pro'`.
- **`link/proguard-rules.pro`** — `-flattenpackagehierarchy` stays here (the SDK's own release build, where it is safe). Added a guard comment so it doesn't regress into the consumer path.

This also stops other broad rules in `proguard-rules.pro` (the catch-all Gson keep, `-keepattributes SourceFile,LineNumberTable`) from leaking into consumer builds.

Config-only change — no source or API change.

### 🎨 Type of change

- [x] Bug fix (non-breaking)

### 👌 Checklist

- [x] I've performed a self-review, and it meets ticket criteria.
- [x] I've commented hard-to-understand areas.
- [ ] I've updated documentation where necessary.
- [ ] I've added tests that prove the fix or feature works.
- [ ] I've tested the changes on a physical device or emulator.

## Verification & release notes

- Could not run `./gradlew :link:assembleRelease` locally (no JDK on the authoring machine) — **CI runs `link:assembleRelease` plus ktlint/detekt/lint/tests, so this PR's checks verify the build.**
- To confirm the fix in the built artifact, inspect the packaged consumer rules — they should **no longer** contain `-flattenpackagehierarchy`:
  ```
  unzip -p link/build/outputs/aar/link-release.aar proguard.txt
  ```
- **A patch release is required for consumers to receive this fix** — consumer ProGuard rules are compiled into the published AAR and cannot be overridden on the consumer side. Suggest bumping `mesh-link` `3.4.1` → `3.4.2` in `gradle/libs.versions.toml` and publishing to Maven Central. No code/API change, so no minor/major bump needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)