### PR TITLE
PRG-2786: Fix ProGuard rules repackaging consumer apps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 3.4.2
+
+### Fixed
+- Removed `-flattenpackagehierarchy` from the rules shipped to consuming apps, so the SDK no longer repackages and renames host-app classes — fixing unreadable, meshconnect-prefixed class names in consumer logs.
+
+### Changed
+- Split the SDK's ProGuard config into `consumer-rules.pro` (public-API keep rules shipped in the AAR) and `proguard-rules.pro` (library-only build options), preventing global obfuscation directives from leaking into host-app builds.
+
 ## 3.4.1
 
 ### Fixed

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -24,7 +24,7 @@ test-runner = "1.6.2"
 test-rules = "1.6.1"
 core-testing = "2.2.0"
 # link
-mesh-link = "3.4.1"
+mesh-link = "3.4.2"
 
 [libraries]
 androidx-appcompat = { group = "androidx.appcompat", name = "appcompat", version.ref = "appcompat" }

--- a/link/build.gradle
+++ b/link/build.gradle
@@ -22,13 +22,13 @@ android {
         minSdk 24
         targetSdk 36
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
-        consumerProguardFiles 'proguard-rules.pro'
+        consumerProguardFiles 'consumer-rules.pro'
         versionCode 1
     }
     buildTypes {
         release {
             minifyEnabled true
-            proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
+            proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro', 'consumer-rules.pro'
         }
     }
     compileOptions {

--- a/link/consumer-rules.pro
+++ b/link/consumer-rules.pro
@@ -16,10 +16,7 @@
 -keep class com.meshconnect.link.LinkEventsKt { *; }
 -keep class com.meshconnect.link.LinkPayloadsKt { *; }
 
-# Retain annotations and inner-class metadata so Gson reflection on the SDK's
-# entities (e.g. @SerializedName, TypeToken generics) keeps working after R8.
--keepattributes *Annotation*, InnerClasses
-
+-keepattributes *Annotation*, InnerClasses, Signature
 #--------- Begin: proguard configuration for Gson ------------
 # https://github.com/google/gson/blob/master/examples/android-proguard-example/proguard.cfg
 -keep public class * implements java.lang.reflect.Type

--- a/link/consumer-rules.pro
+++ b/link/consumer-rules.pro
@@ -1,0 +1,29 @@
+# Consumer ProGuard/R8 rules — shipped inside the AAR and applied to the
+# consuming app's R8 pass.
+#
+# IMPORTANT: keep this file limited to -keep rules that protect the SDK's
+# public API and its runtime-reflected (Gson) types. Do NOT put global
+# obfuscation directives here (e.g. -flattenpackagehierarchy, -repackageclasses,
+# -renamesourcefileattribute) — they would leak into and reshape the entire
+# host app's build. Library-only build options belong in proguard-rules.pro.
+
+# Public API surface — must survive the consumer's R8 pass.
+-keep class com.meshconnect.link.entity.** { *; }
+-keep class com.meshconnect.link.ui.LaunchLink { *; }
+-keep class com.meshconnect.link.ui.LinkExit { *; }
+-keep class com.meshconnect.link.ui.LinkResult { *; }
+-keep class com.meshconnect.link.ui.LinkSuccess { *; }
+-keep class com.meshconnect.link.LinkEventsKt { *; }
+-keep class com.meshconnect.link.LinkPayloadsKt { *; }
+
+# Retain annotations and inner-class metadata so Gson reflection on the SDK's
+# entities (e.g. @SerializedName, TypeToken generics) keeps working after R8.
+-keepattributes *Annotation*, InnerClasses
+
+#--------- Begin: proguard configuration for Gson ------------
+# https://github.com/google/gson/blob/master/examples/android-proguard-example/proguard.cfg
+-keep public class * implements java.lang.reflect.Type
+# Retain generic signatures of TypeToken and its subclasses with R8 version 3.0 and higher.
+-keep,allowobfuscation,allowshrinking class com.google.gson.reflect.TypeToken
+-keep,allowobfuscation,allowshrinking class * extends com.google.gson.reflect.TypeToken
+#--------- End: proguard configuration for Gson ------------

--- a/link/proguard-rules.pro
+++ b/link/proguard-rules.pro
@@ -1,6 +1,8 @@
-# Add project specific ProGuard rules here.
-# You can control the set of applied configuration files using the
-# proguardFiles setting in build.gradle.
+# ProGuard/R8 rules applied to the link module's OWN release build (minifyEnabled).
+#
+# Consumer-facing keep rules live in consumer-rules.pro and are shipped inside the
+# AAR. That file is also referenced by this module's release build (see build.gradle),
+# so the rules below are only the extras needed when minifying the library itself.
 #
 # For more details, see
 #   http://developer.android.com/guide/developing/tools/proguard.html
@@ -12,33 +14,19 @@
 #   public *;
 #}
 
-# Preserve source-file names and line numbers so Crashlytics stack traces include
-# file/line information. Class and method names will still be obfuscated unless a
-# mapping file is uploaded to Crashlytics.
+# Preserve source-file names and line numbers so the library's own stack traces
+# include file/line information. Class and method names will still be obfuscated
+# unless a mapping file is uploaded (e.g. to Crashlytics).
 -keepattributes SourceFile,LineNumberTable
-
-# ProGuard/R8 obfuscation option that moves all obfuscated classes into a single flat package
-# (or a specified package), collapsing the original package structure.
--flattenpackagehierarchy com.meshconnect.link
 
 # If you keep the line number information, uncomment this to
 # hide the original source file name.
 #-renamesourcefileattribute SourceFile
--keepattributes *Annotation*, InnerClasses
+
+# Flatten the SDK's own renamable (non-kept) classes under a single parent package.
+# The argument is the DESTINATION package, not a filter — so this is safe ONLY here,
+# in the library's own build. It must never live in consumer-rules.pro, where it
+# would repackage the entire host app and rename its classes too.
+-flattenpackagehierarchy com.meshconnect.link
+
 -dontnote kotlinx.serialization.AnnotationsKt # core serialization annotations
-
--keep class com.meshconnect.link.entity.** { *; }
--keep class com.meshconnect.link.ui.LaunchLink { *; }
--keep class com.meshconnect.link.ui.LinkExit { *; }
--keep class com.meshconnect.link.ui.LinkResult { *; }
--keep class com.meshconnect.link.ui.LinkSuccess { *; }
--keep class com.meshconnect.link.LinkEventsKt { *; }
--keep class com.meshconnect.link.LinkPayloadsKt { *; }
-
-#--------- Begin: proguard configuration for Gson ------------
-# https://github.com/google/gson/blob/master/examples/android-proguard-example/proguard.cfg
--keep public class * implements java.lang.reflect.Type
-# Retain generic signatures of TypeToken and its subclasses with R8 version 3.0 and higher.
--keep,allowobfuscation,allowshrinking class com.google.gson.reflect.TypeToken
--keep,allowobfuscation,allowshrinking class * extends com.google.gson.reflect.TypeToken
-#--------- End: proguard configuration for Gson ------------


### PR DESCRIPTION
## Overview

[PRG-2786](https://meshconnect.atlassian.net/browse/PRG-2786) - Fix the ProGuard rules in Android SDK

The SDK shipped `-flattenpackagehierarchy com.meshconnect.link` in its consumer rules. Because that directive's argument is the destination package, not a filter, it repackaged the entire host app and renamed its classes — making consumer logs unreadable.

Split the config into `consumer-rules.pro` (public-API keep rules shipped in the AAR) and `proguard-rules.pro` (library-only build options). `-flattenpackagehierarchy` now lives only in the library-only file, so it flattens the SDK's own classes without affecting host apps. Bumped version to 3.4.2.

### 🎨 Type of change

- [x] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [ ] Breaking change (existing functionality affected)
- [ ] Maintenance (tests, build, tooling, performance)
- [ ] Refactor (no functional changes)
- [ ] Documentation update

### 👌 Checklist

- [x] I've performed a self-review, and it meets ticket criteria.
- [x] I've commented hard-to-understand areas.
- [ ] I've updated documentation where necessary.
- [ ] I've added tests that prove the fix or feature works.
- [x] I've tested the changes on a physical device or emulator.


[PRG-2786]: https://meshconnectapi.atlassian.net/browse/PRG-2786?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ