### PR TITLE
PRG-3069: Remove hardcoded Revolut origins

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -273,7 +273,7 @@ Tests live in `link/src/test/kotlin/com/meshconnect/link/`.
 
 - `meshconnect.com` (and subdomains)
 - `walletconnect.com`, `coinbase.com`, `okx.com`, `gemini.com`
-- `stripe.com`, `recaptcha` (Google), `revolut.com`
+- `stripe.com`, `recaptcha` (Google)
 - And others for OAuth flows
 
 To allow all domains (e.g. for testing): set `disableDomainWhiteList = true` in `LinkConfiguration`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## 3.4.4
 
 ### Changed
-- Updated the `WhitelistedOrigins.kt`
+- Removed hardcoded Revolut origins from the WebView domain whitelist.
 
 ## 3.4.3
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 3.4.4
+
+### Changed
+- Updated the `WhitelistedOrigins.kt`
+
 ## 3.4.3
 
 ### Added

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -24,7 +24,7 @@ test-runner = "1.6.2"
 test-rules = "1.6.1"
 core-testing = "2.2.0"
 # link
-mesh-link = "3.4.3"
+mesh-link = "3.4.4"
 
 [libraries]
 androidx-appcompat = { group = "androidx.appcompat", name = "appcompat", version.ref = "appcompat" }

--- a/link/src/main/java/com/meshconnect/link/utils/WhitelistedOrigins.kt
+++ b/link/src/main/java/com/meshconnect/link/utils/WhitelistedOrigins.kt
@@ -19,9 +19,6 @@ internal val whitelistedOrigins =
         "https://api.cb-device-intelligence.com",
         "https://contentmx.okcoin.com",
         "https://www.recaptcha.net",
-        "https://ramp.revolut.codes",
-        "https://sso.revolut.codes",
-        "https://ramp.revolut.com",
     )
 
 internal fun isUrlWhitelisted(


### PR DESCRIPTION
## Overview

[PRG-3069](https://meshconnect.atlassian.net/browse/PRG-3069) - Remove the hardcoded Revolut origins

Removes the hardcoded Revolut origins from the WebView domain whitelist and bumps the SDK version to 3.4.4.

### 🎨 Type of change

- [x] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [ ] Breaking change (existing functionality affected)
- [ ] Maintenance (tests, build, tooling, performance)
- [ ] Refactor (no functional changes)
- [ ] Documentation update

### 👌 Checklist

- [x] I've performed a self-review, and it meets ticket criteria.
- [ ] I've commented hard-to-understand areas.
- [x] I've updated documentation where necessary.
- [ ] I've added tests that prove the fix or feature works.
- [x] I've tested the changes on a physical device or emulator.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[PRG-3069]: https://meshconnectapi.atlassian.net/browse/PRG-3069?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ